### PR TITLE
[IOTSP-6018] Continue even if patch of /etc/init.d/logstash fails

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,6 +52,7 @@
     src: init.d/logstash.patch
     dest: /etc/init.d/logstash
   when: logstash_version_major_minor == '2.3'
+  failed_when: False
   notify: restart logstash
 
 - name: Set KILL_ON_STOP_TIMEOUT in /etc/default/logstash


### PR DESCRIPTION
In 2.3.3 it's ok for it to fail since the fix is already applied there.
